### PR TITLE
Disable batches, but leave commented approach in case we need it later

### DIFF
--- a/src/epicast/fluv_emailer.py
+++ b/src/epicast/fluv_emailer.py
@@ -198,9 +198,10 @@ def main(args, connector_impl=mysql.connector):
   users = get_users(cur, 'email_%s' % (email_type), '1') - get_users(cur, '_debug', '1')
 
   # Slicing users into batches to send notification emails.
-  total_batches = 5
-  current_batch = 4
-  users = set(sorted(users)[current_batch::total_batches])
+  # Disabled 10 apr 2020; so long as load remains in the 200-300s this is not needed
+  # total_batches = 5
+  # current_batch = 4
+  # users = set(sorted(users)[current_batch::total_batches])
 
   log('%d users selected to receive email %s' % (len(users), args.type), True)
   if args.type == 'alerts':


### PR DESCRIPTION
```
Test results for:
 delphi.flu_contest.epicast.fluv_emailer (delphi/flu_contest/epicast/fluv_emailer.py)
Unit:
 delphi.flu-contest.tests.epicast.test_fluv_emailer.Tests.test_connect_to_database: pass
 delphi.flu-contest.tests.epicast.test_fluv_emailer.Tests.test_get_argument_parser: pass
 delphi.flu-contest.tests.epicast.test_fluv_emailer.Tests.test_main_notifications: pass
 delphi.flu-contest.tests.epicast.test_fluv_emailer.Tests.test_main_reminders: pass
 error: 0
  fail: 0
  skip: 0
  pass: 4
Coverage:
 0x: 17
 1x: 26
 2x: 51
 4x: 5
 5x: 2
 12x: 2
 15x: 2
 overall: 83%
✔ All 4 tests passed! 83% (88/105) coverage.
```