### PR TITLE
spread emails over time using random priority

### DIFF
--- a/src/epicast/fluv_emailer.py
+++ b/src/epicast/fluv_emailer.py
@@ -8,6 +8,7 @@ to be emailed.
 import argparse
 import base64
 import json
+import random
 
 # third party
 import mysql.connector
@@ -190,8 +191,15 @@ def main(args, connector_impl=mysql.connector, emailer_impl=emailer):
     if args.print:
       log('%s -> %s\n%s' % (subject, user_email, text), True)
     else:
+      # smear emails over time by setting a random priority which the emailer
+      # will use to determine email batches
+      priority = random.random()
       emailer_impl.queue_email(
-          to=user_email, subject=subject, text=text, html=html)
+          to=user_email,
+          subject=subject,
+          text=text,
+          html=html,
+          priority=priority)
 
   if not args.print:
     emailer_impl.call_emailer()


### PR DESCRIPTION
- the emailer from the operations repo will send emails in batches. use 
random priority here to randomize the set of emails in each batch
- as of now, batches are size 250 each, and go out each hour (so 4 hours 
per 1000 users)
- tests pass